### PR TITLE
display uptime

### DIFF
--- a/pdoser.ino
+++ b/pdoser.ino
@@ -306,10 +306,11 @@ void maybe_update_display() {
         "sunset in %.2f hours",
         sunset_in
       );
+      double uptime = last_screen_update / 3600000;
       snprintf(
         screen[6], sizeof(screen[6]),
-        "%02d sats UTC%+d",
-        sats, utc_offset
+        "%02d sats UTC%+d   %.1fd",
+        sats, utc_offset, uptime
       );
     }
 

--- a/pdoser.ino
+++ b/pdoser.ino
@@ -306,11 +306,11 @@ void maybe_update_display() {
         "sunset in %.2f hours",
         sunset_in
       );
-      double uptime = last_screen_update / 3600000;
+      double uptime_days = last_screen_update / 3600000;
       snprintf(
         screen[6], sizeof(screen[6]),
         "%02d sats UTC%+d   %.1fd",
-        sats, utc_offset, uptime
+        sats, utc_offset, uptime_days
       );
     }
 


### PR DESCRIPTION
It gets displayed at the bottom in XY.Z format. Unit is days and partial days.

Remember, this is set to restart anyway when we detect overflow in the millis() bits. 